### PR TITLE
[JENKINS-30135] Consistent behavior even when the label instance replaced.

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/groovy_label_assignment/GroovyLabelAssignmentAction.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/groovy_label_assignment/GroovyLabelAssignmentAction.java
@@ -23,6 +23,7 @@
  */
 package jp.ikedam.jenkins.plugins.groovy_label_assignment;
 
+import jenkins.model.Jenkins;
 import hudson.model.Label;
 import hudson.model.labels.LabelAssignmentAction;
 import hudson.model.queue.SubTask;
@@ -32,16 +33,39 @@ import hudson.model.queue.SubTask;
  */
 public class GroovyLabelAssignmentAction implements LabelAssignmentAction
 {
-    private Label label;
+    @Deprecated
+    transient private Label label;
+    
+    private final String labelString;
     
     /**
      * Constructor
      * 
-     * @param label assigned label.
+     * @param labelString assigned label expression.
+     * @since 1.1.1
      */
+    public GroovyLabelAssignmentAction(String labelString)
+    {
+        this.labelString = labelString;
+    }
+    
+    /**
+     * @param label
+     * @deprecated use {@link GroovyLabelAssignmentAction#GroovyLabelAssignmentAction(String)}
+     */
+    @Deprecated
     public GroovyLabelAssignmentAction(Label label)
     {
-        this.label = label;
+        this(label.getExpression());
+    }
+    
+    private Object readResolve()
+    {
+        if(label != null)
+        {
+            return new GroovyLabelAssignmentAction(label.getExpression());
+        }
+        return this;
     }
     
     /**
@@ -89,7 +113,7 @@ public class GroovyLabelAssignmentAction implements LabelAssignmentAction
     @Override
     public Label getAssignedLabel(SubTask task)
     {
-        return label;
+        return getAssignedLabel();
     }
     
     
@@ -102,6 +126,15 @@ public class GroovyLabelAssignmentAction implements LabelAssignmentAction
      */
     public Label getAssignedLabel()
     {
-        return label;
+        return Jenkins.getInstance().getLabel(getLabelString());
+    }
+    
+    /**
+     * @return the expression string for the assigned label.
+     * @since 1.1.1
+     */
+    public String getLabelString()
+    {
+        return labelString;
     }
 }

--- a/src/main/java/jp/ikedam/jenkins/plugins/groovy_label_assignment/GroovyLabelAssignmentProperty.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/groovy_label_assignment/GroovyLabelAssignmentProperty.java
@@ -139,10 +139,9 @@ public class GroovyLabelAssignmentProperty extends JobProperty<AbstractProject<?
             return true;
         }
         
-        Label label;
         try
         {
-            label = LabelExpression.parseExpression(labelString);
+            LabelExpression.parseExpression(labelString);
         }
         catch(ANTLRException e)
         {
@@ -150,7 +149,7 @@ public class GroovyLabelAssignmentProperty extends JobProperty<AbstractProject<?
             return false;
         }
         
-        LabelAssignmentAction labelAction = new GroovyLabelAssignmentAction(label);
+        LabelAssignmentAction labelAction = new GroovyLabelAssignmentAction(labelString);
         actions.add(0, labelAction);
         
         LOGGER.info(String.format("%s: label is modified to %s", project.getName(), labelString));

--- a/src/main/resources/jp/ikedam/jenkins/plugins/groovy_label_assignment/GroovyLabelAssignmentAction/summary.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/groovy_label_assignment/GroovyLabelAssignmentAction/summary.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <t:summary icon="computer.png">
         <l:pane title="${%Assigned Label}" width="3">
             <f:block>
-                ${it.assignedLabel.expression}
+                ${it.labelString}
             </f:block>
         </l:pane>
     </t:summary>


### PR DESCRIPTION
[JENKINS-30135](https://issues.jenkins-ci.org/browse/JENKINS-30135)

Groovy-postbuild-plugin-1.1.0 holds `Label` instances in `GroovyLabelAssignmentAction`.
This results in the inconsistent behavior when the label string is once removed from all nodes and added to a node as the `Label` instance is newly created and no longer same to the one `GroovyLabelAssignmentAction` holds.
